### PR TITLE
[WIP] Add plugin API to add common page config tabs

### DIFF
--- a/app/assets/javascripts/pageflow/editor/api.js
+++ b/app/assets/javascripts/pageflow/editor/api.js
@@ -35,6 +35,13 @@ pageflow.EditorApi = pageflow.Object.extend(
     this.pageTypes = new pageflow.PageTypes();
 
     /**
+     * Add tabs to the configuration editor of all pages.
+     * @alias commonPageConfigurationTabs
+     * @memberof module:pageflow/editor.pageflow.editor
+     */
+    this.commonPageConfigurationTabs = new pageflow.CommonPageConfigurationTabs();
+
+    /**
      * Setup editor integration for widget types.
      * @alias widgetType
      * @memberof module:pageflow/editor.pageflow.editor
@@ -240,6 +247,8 @@ pageflow.EditorApi = pageflow.Object.extend(
                    .createConfigurationEditorView(_.extend(options, {
                      model: page.configuration
                    }));
+
+    this.commonPageConfigurationTabs.apply(view);
     return view;
   }
 });

--- a/app/assets/javascripts/pageflow/editor/api/common_page_configuration_tabs.js
+++ b/app/assets/javascripts/pageflow/editor/api/common_page_configuration_tabs.js
@@ -1,0 +1,25 @@
+pageflow.CommonPageConfigurationTabs = pageflow.Object.extend({
+  initialize: function() {
+    this.configureFns = {};
+  },
+
+  register: function(name, configureFn) {
+    this.configureFns[name] = configureFn;
+  },
+
+  apply: function(configurationEditorView) {
+    _.each(this.configureFns, function(configureFn, name) {
+      configurationEditorView.tab(name, function() {
+        configureFn.call(prefixInputDecorator(name, this));
+      });
+    });
+
+    function prefixInputDecorator(name, dsl) {
+      return {
+        input: function(propertyName, view, options) {
+          return dsl.input(name + '_' + propertyName, view, options);
+        }
+      };
+    }
+  }
+});

--- a/doc/adding_common_page_configuration_tabs.md
+++ b/doc/adding_common_page_configuration_tabs.md
@@ -1,0 +1,31 @@
+# Adding Common Page Configuration Tabs
+
+Pageflow plugins can add tabs to the configuration editor view of all
+page types. Values for the additional fields will be stored in the
+page configuration.
+
+```js
+// app/assets/rainbow/editor.js
+pageflow.editor.commonPageConfigurationTabs.register('3d_params', function() {
+  this.input('destination_x', pageflow.SliderInputView);
+  this.input('destination_y', pageflow.SliderInputView);
+  this.input('destination_z', pageflow.SliderInputView);
+});
+```
+
+The attribute stored in the page configuration will be prefixed with
+the tab name to prevent naming conflicts
+e.g. `3d_params_destination_x`.
+
+The following translation keys are used:
+
+```yml
+en:
+  pageflow:
+    common_page_configuration_tabs:
+      3d_params: "3D Parameters"
+    common_page_attributes:
+      3d_params_destination_x:
+        label: X Coordinate
+        inline_help: This text is displayed in the inline help displayed via a small "?" next to the field
+```

--- a/doc/index.md
+++ b/doc/index.md
@@ -13,6 +13,7 @@ extend Pageflow.
 * [Creating a Rails Engine for a Pageflow Plugin](creating_a_pageflow_plugin_rails_engine.md)
 * [Creating File Types](./creating_file_types.md)
 * [Creating Page types](./creating_page_types.md)
+* [Adding common page configuration tabs](./adding_common_page_configuration_tabs.md)
 * [Creating Widget types](./creating_widget_types.md)
 * [Extending Admin Resources](./extending_admin_resources.md)
 * [Adding app news](./adding_app_news.md)

--- a/spec/javascripts/views/edit_page_view_spec.js
+++ b/spec/javascripts/views/edit_page_view_spec.js
@@ -80,4 +80,34 @@ describe('EditPageView', function() {
       expect(configurationEditor.tabLabels()).to.eql(['Specific', 'Common', 'Fallback']);
     });
   });
+
+  it('renders common page configuration tabs with prefixed property names', function() {
+    var api = f.editorApi(function(editor) {
+      editor.pageTypes.register('rainbow', {
+        configurationEditorView: pageflow.ConfigurationEditorView.extend({
+          configure: function() {
+            this.tab('general', function() {
+              this.input('title', pageflow.TextInputView);
+            });
+          }
+        })
+      });
+
+      editor.commonPageConfigurationTabs.register('extras', function() {
+        this.input('text', pageflow.TextInputView);
+      });
+    });
+    var page = new pageflow.Page({template: 'rainbow'});
+    var view = new pageflow.EditPageView({
+      model: page,
+      api: api,
+      tab: 'extras'
+    });
+
+    view.render();
+    var configurationEditor = support.dom.ConfigurationEditor.find(view);
+
+    expect(configurationEditor.tabNames()).to.eql(['general', 'extras']);
+    expect(configurationEditor.inputPropertyNames()).to.eql(['extras_text']);
+  });
 });


### PR DESCRIPTION
**Needs to be reopened against `codevise/pageflow:master` once codevise/pageflow#1164 and #18 are merged.**

Let plugins add tabs to the configuration editors of all pages. This
can be used to store settings for cross page type functionality in the
page configuration.

REDMINE-16823