### PR TITLE
Allow root entries

### DIFF
--- a/admins/pageflow/entry.rb
+++ b/admins/pageflow/entry.rb
@@ -218,6 +218,14 @@ module Pageflow
 
           entry.type_name = default_entry_type.name
         end
+
+        if action_name == 'new' && params[:at] == 'root'
+          entry.build_permalink unless entry.permalink
+          entry.permalink.assign_attributes(slug: '', allow_empty_slug: '1')
+          if (root_dir = entry.site.permalink_directories.find_by(path: ''))
+            entry.permalink.directory = root_dir
+          end
+        end
       end
 
       after_create do |entry|
@@ -288,7 +296,7 @@ module Pageflow
       end
 
       def permitted_attributes
-        result = [:title, :type_name, {permalink_attributes: [:slug, :directory_id]}]
+        result = [:title, :type_name, {permalink_attributes: [:slug, :directory_id, :allow_empty_slug]}]
         target = if !params[:id] && current_user.admin?
                    Account.first
                  elsif params[:id]

--- a/app/assets/javascripts/pageflow/admin/entries.js
+++ b/app/assets/javascripts/pageflow/admin/entries.js
@@ -90,6 +90,9 @@ jQuery(function($) {
     var accountSelect = $('#entry_account_id', this);
     var siteSelect = $('#entry_site_id', this);
     var titleInput = $('#entry_title', this);
+    var allowEmptySlugInput = $('#entry_allow_empty_slug', this);
+    var directorySelect = $('#entry_permalink_attributes_directory_id', this);
+    var slugInput = $('#entry_permalink_attributes_slug', this);
 
     function updateSiteAndEntryTypeInput() {
       var selectedAccountId = accountSelect.val();
@@ -114,6 +117,8 @@ jQuery(function($) {
     function updatePermalinkInput() {
       fetchPermalinkInput(function(response) {
         $('#entry_permalink_attributes_permalink_input').replaceWith(response);
+        directorySelect = $('#entry_permalink_attributes_directory_id');
+        slugInput = $('#entry_permalink_attributes_slug');
       });
     }
 
@@ -139,6 +144,23 @@ jQuery(function($) {
     siteSelect.on('change', updatePermalinkInput);
 
     titleInput.on('change keyup', debounce(updateSlugPlaceholder, 300));
+
+    function enableRootEntry() {
+      slugInput.val('').removeAttr('placeholder');
+      allowEmptySlugInput.val('1');
+      if (directorySelect.length) {
+        directorySelect.val($('.root_entry_link').data('root-directory-id'));
+      }
+    }
+
+    $('.root_entry_link').on('click', function(event) {
+      event.preventDefault();
+      enableRootEntry();
+    });
+
+    if (allowEmptySlugInput.val() === '1') {
+      enableRootEntry();
+    }
   });
 });
 

--- a/app/controllers/pageflow/entries_controller.rb
+++ b/app/controllers/pageflow/entries_controller.rb
@@ -6,9 +6,21 @@ module Pageflow
     include EntryPasswordProtection
 
     def index
-      site = Site.for_request(request).with_home_url.first!
+      site = Site.for_request(request).first!
 
-      redirect_to(site.home_url, allow_other_host: true)
+      entry = PublishedEntry.find_by_permalink(
+        directory: '',
+        slug: '',
+        scope: site.entries
+      )
+
+      if entry
+        delegate_to_entry_type_frontend_app!(entry)
+      elsif site.home_url.present?
+        redirect_to(site.home_url, allow_other_host: true)
+      else
+        raise ActiveRecord::RecordNotFound
+      end
     end
 
     def show

--- a/app/views/admin/entries/_permalink_inputs.html.erb
+++ b/app/views/admin/entries/_permalink_inputs.html.erb
@@ -3,5 +3,17 @@
                base_url: entry.site.canonical_entry_url_prefix.presence ||
                          pretty_site_url(entry.site),
                site: entry.site,
-               slug_placeholder: entry.default_permalink_slug,
+               slug_placeholder: (entry.new_record? && !(entry.permalink && entry.permalink.allow_empty_slug) ? entry.default_permalink_slug : nil),
                hint: entry.new_record? ? nil : t('pageflow.admin.entries.permalink_hint'))%>
+
+<% if entry.new_record? && (root_dir = entry.site.permalink_directories.find_by(path: '')) %>
+  <%= form.hidden_field(:allow_empty_slug, id: 'entry_allow_empty_slug') %>
+  <div class="input">
+    <span class="hint">
+      <%= t('pageflow.admin.entries.root_entry_hint_html',
+             link: link_to(t('pageflow.admin.entries.root_entry_link'), '#',
+                            class: 'root_entry_link',
+                            data: {root_directory_id: root_dir.id})) %>
+    </span>
+  </div>
+<% end %>

--- a/config/locales/new/permalink_redirects.de.yml
+++ b/config/locales/new/permalink_redirects.de.yml
@@ -6,3 +6,5 @@ de:
           Wenn der Permalink geändert wird, nachdem der Beitrag
           bereits veröffentlicht wurde, wird automatisch eine
           Weiterleitung von der alten URL zur neuen URL eingerichtet.
+        root_entry_hint_html: "Sie können den Beitrag auch %{link}."
+        root_entry_link: "am Root-Pfad der Seite anlegen"

--- a/config/locales/new/permalink_redirects.en.yml
+++ b/config/locales/new/permalink_redirects.en.yml
@@ -6,3 +6,5 @@ en:
           Changing the permalink after the story has already been
           published automatically creates a redirect from the old URL
           to the new URL
+        root_entry_hint_html: "You can also %{link}."
+        root_entry_link: "create an entry at the site root"

--- a/spec/controllers/admin/entries_controller_spec.rb
+++ b/spec/controllers/admin/entries_controller_spec.rb
@@ -613,6 +613,20 @@ describe Admin::EntriesController do
       expect(response.body)
         .to have_selector('.permalink_base_url', text: 'some.example.com/foo/')
     end
+
+    it 'enables root entry mode via query param' do
+      user = create(:user)
+      account = create(:account, with_publisher: user)
+      create(:permalink_directory, path: '', site: account.default_site)
+
+      sign_in(user, scope: :user)
+      get :new, params: {at: 'root'}
+
+      expect(response.body)
+        .to have_selector('input[name="entry[permalink_attributes][allow_empty_slug]"][value="1"]', visible: :hidden)
+      expect(response.body)
+        .not_to have_selector('input[name="entry[permalink_attributes][slug]"][placeholder]')
+    end
   end
 
   describe '#create' do

--- a/spec/factories/entries.rb
+++ b/spec/factories/entries.rb
@@ -64,7 +64,8 @@ module Pageflow
 
           entry.build_permalink(
             directory: permalink_directory,
-            slug: evaluator.permalink_attributes.fetch(:slug)
+            slug: evaluator.permalink_attributes.fetch(:slug),
+            allow_empty_slug: evaluator.permalink_attributes[:allow_empty_slug]
           )
         end
       end

--- a/spec/models/concerns/pageflow/permalinkable_spec.rb
+++ b/spec/models/concerns/pageflow/permalinkable_spec.rb
@@ -120,23 +120,38 @@ module Pageflow
       expect(entry).to have(1).error_on('permalink.slug')
     end
 
-    it 'uses default slug based on entry title if empty string' do
+    it 'uses default slug based on entry title if empty string in non-root directory' do
       entry = create(
         :entry,
         title: 'My Example',
         permalink_attributes: {
-          slug: ''
+          slug: '',
+          directory_path: 'en/'
         }
       )
 
       expect(entry.permalink).to have_attributes(slug: 'my-example')
     end
 
+    it 'allows empty slug in root directory' do
+      entry = create(
+        :entry,
+        title: 'My Example',
+        permalink_attributes: {
+          slug: '',
+          allow_empty_slug: '1'
+        }
+      )
+
+      expect(entry.permalink).to have_attributes(slug: '')
+    end
+
     it 'does not enforce uniqueness when generating default slug' do
       account = create(:account)
       permalink_directory = create(
         :permalink_directory,
-        site: account.default_site
+        site: account.default_site,
+        path: 'en/'
       )
       create(
         :entry,


### PR DESCRIPTION
## Summary
- allow slugs to be empty for root directory permalinks
- use hidden field and hint link for creating root entries
- support `at=root` param for new entry form
- render root entry from `/` if present
- add specs for root entry behaviour

## Testing
- `bin/rspec spec/models/concerns/pageflow/permalinkable_spec.rb spec/requests/pageflow/entries_index_request_spec.rb spec/controllers/admin/entries_controller_spec.rb`

------
https://chatgpt.com/codex/tasks/task_b_686cf44dc5e08324b25964d293bfe40f